### PR TITLE
Clarify flow-up count indicator

### DIFF
--- a/frontend/src/components/DoItem.tsx
+++ b/frontend/src/components/DoItem.tsx
@@ -423,10 +423,12 @@ export function DoItem({ item }: Props) {
           ) : (
             item.flow_count > 0 && !item.completed && (
               <span
-                className="text-xs text-[#7b8ea6]/60 flex-none"
+                className="flex-none inline-flex items-center gap-1 rounded-full border border-[#7b8ea6]/20 bg-[#7b8ea6]/8 px-2 py-0.5 text-[11px] font-medium text-[#52657f]"
                 title={`Flowed up ${item.flow_count} time${item.flow_count === 1 ? "" : "s"}`}
+                aria-label={`Flowed up ${item.flow_count} time${item.flow_count === 1 ? "" : "s"}`}
               >
-                ↑{item.flow_count}
+                <span aria-hidden>↑</span>
+                <span>Flowed {item.flow_count}×</span>
               </span>
             )
           )}


### PR DESCRIPTION
Closes #2

## Summary
- replace the tiny bare `↑{count}` marker with a clearer labeled pill
- keep the existing hover title, while making the indicator more legible at a glance
- preserve the existing behavior of only showing the indicator for uncompleted non-maintenance dos with a non-zero flow count

## Why
The old indicator was easy to miss and not very self-explanatory. This change makes the flow-up count more readable without adding much visual clutter.

## Checks
- attempted: `npm run build` in `frontend/`
- blocked: `tsc` not installed in the current checkout environment
