### PR TITLE
Add Google Calendar OAuth scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you want to test Google Calendar OAuth locally, you will also need:
 
 See `docs/google-calendar-setup-checklist.md` for the human-in-the-loop setup steps.
 
+The Google OAuth values are populated from `backend/.env` locally (and from deployed environment variables in production).
+
 ### 2. Frontend
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ uvicorn app.main:app --reload
 
 API docs are available at `http://localhost:8000/docs` once the server is running.
 
+### Google Calendar OAuth notes
+If you want to test Google Calendar OAuth locally, you will also need:
+- a Google Cloud project
+- Google Calendar API enabled
+- OAuth client credentials
+- a redirect URI registered for:
+  - `http://localhost:8000/api/v1/integrations/google-calendar/callback`
+
+See `docs/google-calendar-setup-checklist.md` for the human-in-the-loop setup steps.
+
 ### 2. Frontend
 
 ```bash
@@ -90,6 +100,10 @@ SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_KEY=your-service-role-key
 ALLOWED_ORIGINS=http://localhost:5173
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google-calendar/callback
+GOOGLE_OAUTH_STATE_SECRET=your-google-oauth-state-secret
 ```
 
 ### `frontend/.env`

--- a/backend/app/api/v1/endpoints/google_calendar.py
+++ b/backend/app/api/v1/endpoints/google_calendar.py
@@ -33,6 +33,16 @@ async def google_calendar_callback(
     state: str | None = Query(default=None),
     error: str | None = Query(default=None),
 ):
+    """
+    Handle the browser redirect back from Google OAuth.
+
+    This returns a tiny HTML page on purpose because Google redirects a browser
+    directly to this endpoint. At this stage, the simplest UX is to show a human-
+    readable success/failure page after the token exchange completes.
+
+    Later, once the frontend integration is fuller, this could instead redirect
+    back into a dedicated frontend route with a more polished connected-state UX.
+    """
     if error:
         return HTMLResponse(
             content=f"<html><body><h1>Google Calendar connection failed</h1><p>{error}</p></body></html>",

--- a/backend/app/api/v1/endpoints/google_calendar.py
+++ b/backend/app/api/v1/endpoints/google_calendar.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import HTMLResponse
+
+from app.core.config import settings
+from app.middleware.auth import get_current_user
+from app.services.google_oauth import (
+    build_google_auth_url,
+    create_google_oauth_state,
+    exchange_google_code,
+    fetch_google_userinfo,
+    google_oauth_configured,
+    parse_google_oauth_state,
+)
+
+router = APIRouter()
+
+
+@router.get("/connect")
+async def google_calendar_connect(current_user: dict = Depends(get_current_user)):
+    if not google_oauth_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google OAuth is not configured",
+        )
+
+    state = create_google_oauth_state(user_id=current_user["sub"])
+    return {"auth_url": build_google_auth_url(state=state)}
+
+
+@router.get("/callback", response_class=HTMLResponse)
+async def google_calendar_callback(
+    code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+):
+    if error:
+        return HTMLResponse(
+            content=f"<html><body><h1>Google Calendar connection failed</h1><p>{error}</p></body></html>",
+            status_code=400,
+        )
+
+    if not code or not state:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing OAuth code or state")
+
+    try:
+        state_payload = parse_google_oauth_state(state)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    if not google_oauth_configured():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google OAuth is not configured",
+        )
+
+    token_payload = await exchange_google_code(code=code)
+    access_token = token_payload.get("access_token")
+    if not access_token:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Google token exchange failed")
+
+    profile = await fetch_google_userinfo(access_token=access_token)
+
+    # Persistence is intentionally deferred to issue #19.
+    html = f"""
+    <html>
+      <body style=\"font-family: sans-serif; padding: 24px;\">
+        <h1>Google Calendar connection verified</h1>
+        <p><strong>Status:</strong> OAuth callback succeeded.</p>
+        <p><strong>Google account:</strong> {profile.get('email', 'unknown')}</p>
+        <p><strong>Flow-Do user:</strong> {state_payload.get('user_id')}</p>
+        <p>Token persistence and connected-state storage are handled in the next implementation step.</p>
+      </body>
+    </html>
+    """
+    return HTMLResponse(content=html)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import health, users, dos, internal
+from app.api.v1.endpoints import health, users, dos, internal, google_calendar
 
 router = APIRouter()
 
@@ -7,3 +7,4 @@ router.include_router(health.router, prefix="/health", tags=["health"])
 router.include_router(users.router, prefix="/users", tags=["users"])
 router.include_router(dos.router, prefix="/dos", tags=["dos"])
 router.include_router(internal.router, prefix="/internal", tags=["internal"])
+router.include_router(google_calendar.router, prefix="/integrations/google-calendar", tags=["google-calendar"])

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,5 +26,11 @@ class Settings(BaseSettings):
     # Set this to a long random string. Generate one with: openssl rand -hex 32
     CRON_SECRET: str = ""
 
+    # Google Calendar OAuth configuration.
+    GOOGLE_CLIENT_ID: str = ""
+    GOOGLE_CLIENT_SECRET: str = ""
+    GOOGLE_REDIRECT_URI: str = ""
+    GOOGLE_OAUTH_STATE_SECRET: str = ""
+
 
 settings = Settings()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     CRON_SECRET: str = ""
 
     # Google Calendar OAuth configuration.
+    # These are populated from backend/.env (or the deployed service environment).
     GOOGLE_CLIENT_ID: str = ""
     GOOGLE_CLIENT_SECRET: str = ""
     GOOGLE_REDIRECT_URI: str = ""

--- a/backend/app/services/google_oauth.py
+++ b/backend/app/services/google_oauth.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+"""
+Google OAuth helper functions for Flow-Do.
+
+How the pieces fit together:
+1. `google_oauth_configured()` guards whether the backend has the required env vars.
+2. `create_google_oauth_state()` creates a signed state payload tied to the current Flow-Do user.
+3. `build_google_auth_url()` turns that state into a Google consent-screen URL.
+4. After Google redirects back, `parse_google_oauth_state()` verifies the signed state.
+5. `exchange_google_code()` swaps the callback code for access/refresh tokens.
+6. `fetch_google_userinfo()` verifies which Google account was actually connected.
+7. `refresh_google_access_token()` is used later once persisted connections start expiring.
+
+This module intentionally focuses on OAuth mechanics and Google HTTP calls.
+Persistence of connected accounts/tokens is handled elsewhere.
+"""
+
 import base64
 import hashlib
 import hmac
 import json
 import secrets
 import time
+from typing import TypedDict
 from urllib.parse import urlencode
 
 import httpx
@@ -18,7 +35,30 @@ GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
 GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
 
 
+class GoogleOAuthStatePayload(TypedDict):
+    user_id: str
+    nonce: str
+    iat: int
+
+
+class GoogleTokenPayload(TypedDict, total=False):
+    access_token: str
+    refresh_token: str
+    expires_in: int
+    scope: str
+    token_type: str
+
+
+class GoogleUserInfo(TypedDict, total=False):
+    sub: str
+    email: str
+    email_verified: bool
+    name: str
+    picture: str
+
+
 def google_oauth_configured() -> bool:
+    """Return True when the required Google OAuth env vars are present."""
     return all(
         [
             settings.GOOGLE_CLIENT_ID,
@@ -30,11 +70,13 @@ def google_oauth_configured() -> bool:
 
 
 def _b64url(data: bytes) -> str:
+    """Encode bytes as URL-safe base64 without trailing padding."""
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
 
 
 def create_google_oauth_state(*, user_id: str) -> str:
-    payload = {
+    """Create a signed short-lived OAuth state value tied to the current Flow-Do user."""
+    payload: GoogleOAuthStatePayload = {
         "user_id": user_id,
         "nonce": secrets.token_urlsafe(12),
         "iat": int(time.time()),
@@ -49,7 +91,8 @@ def create_google_oauth_state(*, user_id: str) -> str:
     return f"{payload_part}.{_b64url(sig)}"
 
 
-def parse_google_oauth_state(state: str, *, max_age_seconds: int = 900) -> dict:
+def parse_google_oauth_state(state: str, *, max_age_seconds: int = 900) -> GoogleOAuthStatePayload:
+    """Verify and decode a previously signed OAuth state payload."""
     try:
         payload_part, sig_part = state.split(".", 1)
     except ValueError as exc:
@@ -72,6 +115,7 @@ def parse_google_oauth_state(state: str, *, max_age_seconds: int = 900) -> dict:
 
 
 def build_google_auth_url(*, state: str) -> str:
+    """Build the Google consent-screen URL for the Calendar read-only scope."""
     query = urlencode(
         {
             "client_id": settings.GOOGLE_CLIENT_ID,
@@ -87,7 +131,8 @@ def build_google_auth_url(*, state: str) -> str:
     return f"{GOOGLE_AUTH_URL}?{query}"
 
 
-async def exchange_google_code(*, code: str) -> dict:
+async def exchange_google_code(*, code: str) -> GoogleTokenPayload:
+    """Exchange the Google OAuth callback code for access/refresh tokens."""
     async with httpx.AsyncClient(timeout=20) as client:
         response = await client.post(
             GOOGLE_TOKEN_URL,
@@ -103,7 +148,24 @@ async def exchange_google_code(*, code: str) -> dict:
         return response.json()
 
 
-async def fetch_google_userinfo(*, access_token: str) -> dict:
+async def refresh_google_access_token(*, refresh_token: str) -> GoogleTokenPayload:
+    """Refresh an expired Google access token using the saved refresh token."""
+    async with httpx.AsyncClient(timeout=20) as client:
+        response = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "client_id": settings.GOOGLE_CLIENT_ID,
+                "client_secret": settings.GOOGLE_CLIENT_SECRET,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def fetch_google_userinfo(*, access_token: str) -> GoogleUserInfo:
+    """Fetch basic profile information for the newly connected Google account."""
     async with httpx.AsyncClient(timeout=20) as client:
         response = await client.get(
             GOOGLE_USERINFO_URL,

--- a/backend/app/services/google_oauth.py
+++ b/backend/app/services/google_oauth.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from urllib.parse import urlencode
+
+import httpx
+
+from app.core.config import settings
+
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
+
+
+def google_oauth_configured() -> bool:
+    return all(
+        [
+            settings.GOOGLE_CLIENT_ID,
+            settings.GOOGLE_CLIENT_SECRET,
+            settings.GOOGLE_REDIRECT_URI,
+            settings.GOOGLE_OAUTH_STATE_SECRET,
+        ]
+    )
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def create_google_oauth_state(*, user_id: str) -> str:
+    payload = {
+        "user_id": user_id,
+        "nonce": secrets.token_urlsafe(12),
+        "iat": int(time.time()),
+    }
+    payload_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    payload_part = _b64url(payload_bytes)
+    sig = hmac.new(
+        settings.GOOGLE_OAUTH_STATE_SECRET.encode("utf-8"),
+        payload_part.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return f"{payload_part}.{_b64url(sig)}"
+
+
+def parse_google_oauth_state(state: str, *, max_age_seconds: int = 900) -> dict:
+    try:
+        payload_part, sig_part = state.split(".", 1)
+    except ValueError as exc:
+        raise ValueError("Invalid OAuth state") from exc
+
+    expected_sig = hmac.new(
+        settings.GOOGLE_OAUTH_STATE_SECRET.encode("utf-8"),
+        payload_part.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    provided_sig = base64.urlsafe_b64decode(sig_part + "=")
+    if not hmac.compare_digest(expected_sig, provided_sig):
+        raise ValueError("Invalid OAuth state signature")
+
+    payload = json.loads(base64.urlsafe_b64decode(payload_part + "=").decode("utf-8"))
+    iat = int(payload.get("iat", 0))
+    if int(time.time()) - iat > max_age_seconds:
+        raise ValueError("OAuth state expired")
+    return payload
+
+
+def build_google_auth_url(*, state: str) -> str:
+    query = urlencode(
+        {
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+            "response_type": "code",
+            "access_type": "offline",
+            "prompt": "consent",
+            "scope": GOOGLE_CALENDAR_SCOPE,
+            "state": state,
+            "include_granted_scopes": "true",
+        }
+    )
+    return f"{GOOGLE_AUTH_URL}?{query}"
+
+
+async def exchange_google_code(*, code: str) -> dict:
+    async with httpx.AsyncClient(timeout=20) as client:
+        response = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "code": code,
+                "client_id": settings.GOOGLE_CLIENT_ID,
+                "client_secret": settings.GOOGLE_CLIENT_SECRET,
+                "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+                "grant_type": "authorization_code",
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def fetch_google_userinfo(*, access_token: str) -> dict:
+    async with httpx.AsyncClient(timeout=20) as client:
+        response = await client.get(
+            GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        response.raise_for_status()
+        return response.json()

--- a/backend/env.example
+++ b/backend/env.example
@@ -4,7 +4,9 @@ SUPABASE_SERVICE_KEY=your-service-role-key
 ALLOWED_ORIGINS=http://localhost:5173
 # Generate with: openssl rand -hex 32
 CRON_SECRET=your-secret-here
+# These values are loaded by backend/app/core/config.py from the backend environment.
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google-calendar/callback
+# Generate with: openssl rand -hex 32
 GOOGLE_OAUTH_STATE_SECRET=your-google-oauth-state-secret

--- a/backend/env.example
+++ b/backend/env.example
@@ -4,3 +4,7 @@ SUPABASE_SERVICE_KEY=your-service-role-key
 ALLOWED_ORIGINS=http://localhost:5173
 # Generate with: openssl rand -hex 32
 CRON_SECRET=your-secret-here
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/integrations/google-calendar/callback
+GOOGLE_OAUTH_STATE_SECRET=your-google-oauth-state-secret

--- a/docs/google-calendar-integration-analysis.md
+++ b/docs/google-calendar-integration-analysis.md
@@ -1,0 +1,25 @@
+# Google Calendar Integration Analysis
+
+## Recommended staged approach
+1. Add Google OAuth configuration and backend callback flow
+2. Persist Google Calendar connection data securely
+3. Add backend endpoint to fetch today’s primary-calendar events
+4. Add frontend connect/disconnect UI
+5. Display today’s calendar events alongside Today dos
+6. Explore calendar-aware Today layout
+7. Later: drag dos into open calendar time sections
+
+## Human-in-the-loop setup required
+- create/select Google Cloud project
+- enable Google Calendar API
+- configure OAuth consent screen
+- create OAuth client credentials
+- register redirect URIs
+- add Google OAuth env vars/secrets
+- add test users if needed during development
+
+## MVP recommendation
+- read-only first
+- primary calendar only
+- today only
+- simple event list / adjacent view before any drag/drop scheduling

--- a/docs/google-calendar-setup-checklist.md
+++ b/docs/google-calendar-setup-checklist.md
@@ -1,0 +1,44 @@
+# Google Calendar Setup Checklist
+
+## Purpose
+Human-in-the-loop setup required before Flow-Do can complete Google Calendar OAuth locally or in production.
+
+---
+
+## Google Cloud setup
+- [ ] Create or choose a Google Cloud project
+- [ ] Enable the **Google Calendar API**
+- [ ] Configure the **OAuth consent screen**
+- [ ] Add Josh as a test user if the app is in testing mode
+- [ ] Create an OAuth client ID / client secret
+
+---
+
+## Redirect URIs
+Register the exact backend callback URI(s) that Flow-Do will use.
+
+### Likely examples
+- local: `http://localhost:8000/api/v1/integrations/google-calendar/callback`
+- production: `https://<your-backend-domain>/api/v1/integrations/google-calendar/callback`
+
+---
+
+## Backend env vars needed
+Add these to the backend environment:
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_REDIRECT_URI`
+- `GOOGLE_OAUTH_STATE_SECRET`
+
+Suggested state secret generation:
+```bash
+openssl rand -hex 32
+```
+
+---
+
+## Notes
+- This first implementation only verifies OAuth and callback flow.
+- Persistent connection storage is handled in issue #19.
+- Read-only event fetching is handled in issue #20.

--- a/frontend/src/lib/googleCalendar.ts
+++ b/frontend/src/lib/googleCalendar.ts
@@ -1,0 +1,6 @@
+import { api } from "@/lib/api"
+
+export async function getGoogleCalendarConnectUrl() {
+  const { data } = await api.get<{ auth_url: string }>("/api/v1/integrations/google-calendar/connect")
+  return data.auth_url
+}


### PR DESCRIPTION
Closes #18

## Summary
- add Google OAuth config/env support
- add backend Google OAuth service for auth URL, signed state, token exchange, and userinfo fetch
- add backend connect/callback endpoints for Google Calendar OAuth
- add setup/checklist docs for the required Google Cloud configuration
- add a tiny frontend helper for retrieving the backend connect URL

## Scope note
This PR intentionally stops short of persistence. OAuth callback success is verified, but token storage/connected-state persistence are handled in #19.

## Human-in-the-loop setup required
- Google Cloud project + Calendar API enabled
- OAuth consent screen configured
- OAuth client credentials created
- redirect URI registered
- backend Google env vars configured

## Checks
- 
