### PR TITLE
Persist Google Calendar connections

### DIFF
--- a/backend/app/api/v1/endpoints/google_calendar.py
+++ b/backend/app/api/v1/endpoints/google_calendar.py
@@ -11,6 +11,12 @@ from app.services.google_oauth import (
     google_oauth_configured,
     parse_google_oauth_state,
 )
+from app.services.google_calendar_connections import (
+    delete_google_calendar_connection,
+    get_google_calendar_connection,
+    upsert_google_calendar_connection,
+)
+from app.schemas.google_calendar import GoogleCalendarConnectionStatus
 
 router = APIRouter()
 
@@ -25,6 +31,26 @@ async def google_calendar_connect(current_user: dict = Depends(get_current_user)
 
     state = create_google_oauth_state(user_id=current_user["sub"])
     return {"auth_url": build_google_auth_url(state=state)}
+
+
+@router.get("/status", response_model=GoogleCalendarConnectionStatus)
+async def google_calendar_status(current_user: dict = Depends(get_current_user)):
+    connection = get_google_calendar_connection(user_id=current_user["sub"])
+    if not connection:
+        return GoogleCalendarConnectionStatus(connected=False)
+    return GoogleCalendarConnectionStatus(
+        connected=True,
+        google_email=connection.get("google_email"),
+        scope=connection.get("scope"),
+        token_type=connection.get("token_type"),
+        expires_at=connection.get("expires_at"),
+    )
+
+
+@router.post("/disconnect")
+async def google_calendar_disconnect(current_user: dict = Depends(get_current_user)):
+    delete_google_calendar_connection(user_id=current_user["sub"])
+    return {"ok": True}
 
 
 @router.get("/callback", response_class=HTMLResponse)
@@ -59,16 +85,20 @@ async def google_calendar_callback(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Google token exchange failed")
 
     profile = await fetch_google_userinfo(access_token=access_token)
+    upsert_google_calendar_connection(
+        user_id=state_payload["user_id"],
+        profile=profile,
+        token_payload=token_payload,
+    )
 
-    # Persistence is intentionally deferred to issue #19.
     html = f"""
     <html>
       <body style=\"font-family: sans-serif; padding: 24px;\">
-        <h1>Google Calendar connection verified</h1>
-        <p><strong>Status:</strong> OAuth callback succeeded.</p>
+        <h1>Google Calendar connected</h1>
+        <p><strong>Status:</strong> OAuth callback succeeded and the connection was saved.</p>
         <p><strong>Google account:</strong> {profile.get('email', 'unknown')}</p>
         <p><strong>Flow-Do user:</strong> {state_payload.get('user_id')}</p>
-        <p>Token persistence and connected-state storage are handled in the next implementation step.</p>
+        <p>You can return to Flow-Do and continue setup.</p>
       </body>
     </html>
     """

--- a/backend/app/schemas/google_calendar.py
+++ b/backend/app/schemas/google_calendar.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class GoogleCalendarConnectionStatus(BaseModel):
+    connected: bool
+    google_email: str | None = None
+    scope: str | None = None
+    token_type: str | None = None
+    expires_at: datetime | None = None

--- a/backend/app/services/google_calendar_connections.py
+++ b/backend/app/services/google_calendar_connections.py
@@ -10,6 +10,13 @@ def _iso_or_none(value: datetime | None) -> str | None:
 
 
 def upsert_google_calendar_connection(*, user_id: str, profile: dict, token_payload: dict) -> dict:
+    """
+    Create or update the persisted Google Calendar connection row for a Flow-Do user.
+
+    `google_subject` stores Google's stable account subject identifier (`sub` from
+    the userinfo payload). That gives us an account identity field that is more
+    stable and semantically correct than email alone.
+    """
     expires_at = None
     expires_in = token_payload.get("expires_in")
     if expires_in is not None:
@@ -36,6 +43,16 @@ def upsert_google_calendar_connection(*, user_id: str, profile: dict, token_payl
 
 
 def get_google_calendar_connection(*, user_id: str) -> dict | None:
+    """
+    Return the persisted Google Calendar connection row for a user, if one exists.
+
+    `maybe_single()` is a Supabase helper meaning:
+    - return a single row if exactly one matches
+    - return `None`/empty data if zero rows match
+    - avoid treating the no-row case as an exception for this lookup
+
+    That fits this table because we enforce one Google Calendar connection row per user.
+    """
     result = (
         supabase.table("google_calendar_connections")
         .select("id,user_id,google_email,google_subject,scope,token_type,expires_at,created_at,updated_at")
@@ -47,6 +64,7 @@ def get_google_calendar_connection(*, user_id: str) -> dict | None:
 
 
 def get_google_calendar_token_data(*, user_id: str) -> dict | None:
+    """Return the token-related fields for a user's Google Calendar connection, if present."""
     result = (
         supabase.table("google_calendar_connections")
         .select("access_token,refresh_token,expires_at,scope,token_type")
@@ -58,4 +76,5 @@ def get_google_calendar_token_data(*, user_id: str) -> dict | None:
 
 
 def delete_google_calendar_connection(*, user_id: str) -> None:
+    """Delete a user's persisted Google Calendar connection, if it exists."""
     supabase.table("google_calendar_connections").delete().eq("user_id", user_id).execute()

--- a/backend/app/services/google_calendar_connections.py
+++ b/backend/app/services/google_calendar_connections.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.core.supabase import supabase
+
+
+def _iso_or_none(value: datetime | None) -> str | None:
+    return value.astimezone(timezone.utc).isoformat() if value else None
+
+
+def upsert_google_calendar_connection(*, user_id: str, profile: dict, token_payload: dict) -> dict:
+    expires_at = None
+    expires_in = token_payload.get("expires_in")
+    if expires_in is not None:
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+
+    row = {
+        "user_id": user_id,
+        "google_email": profile.get("email"),
+        "google_subject": profile.get("sub"),
+        "access_token": token_payload.get("access_token"),
+        "refresh_token": token_payload.get("refresh_token"),
+        "scope": token_payload.get("scope"),
+        "token_type": token_payload.get("token_type"),
+        "expires_at": _iso_or_none(expires_at),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    result = (
+        supabase.table("google_calendar_connections")
+        .upsert(row, on_conflict="user_id")
+        .execute()
+    )
+    return result.data[0]
+
+
+def get_google_calendar_connection(*, user_id: str) -> dict | None:
+    result = (
+        supabase.table("google_calendar_connections")
+        .select("id,user_id,google_email,google_subject,scope,token_type,expires_at,created_at,updated_at")
+        .eq("user_id", user_id)
+        .maybe_single()
+        .execute()
+    )
+    return result.data
+
+
+def get_google_calendar_token_data(*, user_id: str) -> dict | None:
+    result = (
+        supabase.table("google_calendar_connections")
+        .select("access_token,refresh_token,expires_at,scope,token_type")
+        .eq("user_id", user_id)
+        .maybe_single()
+        .execute()
+    )
+    return result.data
+
+
+def delete_google_calendar_connection(*, user_id: str) -> None:
+    supabase.table("google_calendar_connections").delete().eq("user_id", user_id).execute()

--- a/frontend/src/lib/googleCalendar.ts
+++ b/frontend/src/lib/googleCalendar.ts
@@ -1,6 +1,24 @@
 import { api } from "@/lib/api"
 
+export interface GoogleCalendarConnectionStatus {
+  connected: boolean
+  google_email: string | null
+  scope: string | null
+  token_type: string | null
+  expires_at: string | null
+}
+
 export async function getGoogleCalendarConnectUrl() {
   const { data } = await api.get<{ auth_url: string }>("/api/v1/integrations/google-calendar/connect")
   return data.auth_url
+}
+
+export async function getGoogleCalendarStatus() {
+  const { data } = await api.get<GoogleCalendarConnectionStatus>("/api/v1/integrations/google-calendar/status")
+  return data
+}
+
+export async function disconnectGoogleCalendar() {
+  const { data } = await api.post<{ ok: boolean }>("/api/v1/integrations/google-calendar/disconnect", {})
+  return data
 }

--- a/supabase/migrations/20260322010000_create_google_calendar_connections.sql
+++ b/supabase/migrations/20260322010000_create_google_calendar_connections.sql
@@ -1,0 +1,14 @@
+CREATE TABLE google_calendar_connections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  google_email text,
+  google_subject text,
+  access_token text NOT NULL,
+  refresh_token text,
+  scope text,
+  token_type text,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id)
+);

--- a/supabase/migrations/20260322010000_create_google_calendar_connections.sql
+++ b/supabase/migrations/20260322010000_create_google_calendar_connections.sql
@@ -2,6 +2,8 @@ CREATE TABLE google_calendar_connections (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   google_email text,
+  -- The stable Google account subject/user id returned by Google's userinfo endpoint.
+  -- This is distinct from email and is safer to use as an identity field if needed later.
   google_subject text,
   access_token text NOT NULL,
   refresh_token text,


### PR DESCRIPTION
Closes #19

## Summary
- add a  table migration
- persist Google Calendar OAuth connection data on callback
- add backend status and disconnect endpoints
- add backend service helpers for Google Calendar connection persistence
- add a frontend helper for connection status/disconnect

## Scope note
This PR is intentionally stacked on top of #18 and uses its OAuth scaffolding as the base.

## Checks
- 
