### PR TITLE
Add Google Calendar today events endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/google_calendar.py
+++ b/backend/app/api/v1/endpoints/google_calendar.py
@@ -1,3 +1,6 @@
+from datetime import date, datetime, timezone
+
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import HTMLResponse
 
@@ -10,13 +13,17 @@ from app.services.google_oauth import (
     fetch_google_userinfo,
     google_oauth_configured,
     parse_google_oauth_state,
+    refresh_google_access_token,
 )
 from app.services.google_calendar_connections import (
     delete_google_calendar_connection,
     get_google_calendar_connection,
+    get_google_calendar_token_data,
     upsert_google_calendar_connection,
 )
+from app.services.google_calendar import fetch_primary_calendar_events_for_day, update_google_calendar_tokens
 from app.schemas.google_calendar import GoogleCalendarConnectionStatus
+from app.schemas.google_calendar_events import GoogleCalendarTodayEventsResponse
 
 router = APIRouter()
 
@@ -45,6 +52,38 @@ async def google_calendar_status(current_user: dict = Depends(get_current_user))
         token_type=connection.get("token_type"),
         expires_at=connection.get("expires_at"),
     )
+
+
+@router.get("/events/today", response_model=GoogleCalendarTodayEventsResponse)
+async def google_calendar_today_events(current_user: dict = Depends(get_current_user)):
+    token_data = get_google_calendar_token_data(user_id=current_user["sub"])
+    if not token_data:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Google Calendar is not connected")
+
+    access_token = token_data.get("access_token")
+    refresh_token = token_data.get("refresh_token")
+    expires_at_raw = token_data.get("expires_at")
+
+    if not access_token:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Google Calendar access token missing")
+
+    if expires_at_raw:
+        expires_at = datetime.fromisoformat(expires_at_raw.replace("Z", "+00:00"))
+        if expires_at <= datetime.now(timezone.utc):
+            if not refresh_token:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Google Calendar token expired")
+            refreshed = await refresh_google_access_token(refresh_token=refresh_token)
+            if not refreshed.get("access_token"):
+                raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Google token refresh failed")
+            update_google_calendar_tokens(user_id=current_user["sub"], token_payload=refreshed)
+            access_token = refreshed["access_token"]
+
+    try:
+        events = await fetch_primary_calendar_events_for_day(access_token=access_token, day=date.today())
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Google Calendar request failed") from exc
+
+    return GoogleCalendarTodayEventsResponse(date=date.today(), events=events)
 
 
 @router.post("/disconnect")

--- a/backend/app/schemas/google_calendar_events.py
+++ b/backend/app/schemas/google_calendar_events.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class GoogleCalendarEvent(BaseModel):
+    id: str
+    summary: str | None = None
+    status: str | None = None
+    html_link: str | None = None
+    start: dict
+    end: dict
+
+
+class GoogleCalendarTodayEventsResponse(BaseModel):
+    date: date
+    events: list[GoogleCalendarEvent]

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+import httpx
+
+from app.core.supabase import supabase
+
+GOOGLE_CALENDAR_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+
+
+def _utc_day_bounds(day: date) -> tuple[str, str]:
+    start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    return start.isoformat(), end.isoformat()
+
+
+async def fetch_primary_calendar_events_for_day(*, access_token: str, day: date) -> list[dict]:
+    time_min, time_max = _utc_day_bounds(day)
+    async with httpx.AsyncClient(timeout=20) as client:
+        response = await client.get(
+            GOOGLE_CALENDAR_EVENTS_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            params={
+                "singleEvents": "true",
+                "orderBy": "startTime",
+                "timeMin": time_min,
+                "timeMax": time_max,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("items", [])
+
+
+def update_google_calendar_tokens(*, user_id: str, token_payload: dict) -> None:
+    expires_at = None
+    expires_in = token_payload.get("expires_in")
+    if expires_in is not None:
+        expires_at = (datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))).isoformat()
+
+    updates = {
+        "access_token": token_payload.get("access_token"),
+        "token_type": token_payload.get("token_type"),
+        "scope": token_payload.get("scope"),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "expires_at": expires_at,
+    }
+    if token_payload.get("refresh_token"):
+        updates["refresh_token"] = token_payload.get("refresh_token")
+
+    supabase.table("google_calendar_connections").update(updates).eq("user_id", user_id).execute()

--- a/backend/app/services/google_oauth.py
+++ b/backend/app/services/google_oauth.py
@@ -103,6 +103,21 @@ async def exchange_google_code(*, code: str) -> dict:
         return response.json()
 
 
+async def refresh_google_access_token(*, refresh_token: str) -> dict:
+    async with httpx.AsyncClient(timeout=20) as client:
+        response = await client.post(
+            GOOGLE_TOKEN_URL,
+            data={
+                "client_id": settings.GOOGLE_CLIENT_ID,
+                "client_secret": settings.GOOGLE_CLIENT_SECRET,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+
 async def fetch_google_userinfo(*, access_token: str) -> dict:
     async with httpx.AsyncClient(timeout=20) as client:
         response = await client.get(


### PR DESCRIPTION
Closes #20

## Summary
- add a backend endpoint for today\'s primary Google Calendar events
- add a Google Calendar service for fetching primary-calendar events for a given day
- add a response schema for today\'s events
- add refresh-token support so expired access tokens can be refreshed before the calendar request
- update persisted Google token data after refresh

## Scope
This PR stays backend-only and focused on read-only event fetch for the primary calendar. Frontend connect/disconnect UI remains in #21, and actual event display remains in #22.

## Checks
- 
