### PR TITLE
Show maintenance task completion instances in a collapsible drawer

### DIFF
--- a/backend/app/api/v1/endpoints/dos.py
+++ b/backend/app/api/v1/endpoints/dos.py
@@ -113,7 +113,7 @@ async def list_maintenance_logs(
 
     result = (
         supabase.table("maintenance_logs")
-        .select("*")
+        .select("id,do_id,logged_at")
         .eq("do_id", do_id)
         .eq("user_id", _user_id(current_user))
         .order("logged_at", desc=True)

--- a/backend/app/api/v1/endpoints/dos.py
+++ b/backend/app/api/v1/endpoints/dos.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.middleware.auth import get_current_user
 from app.core.supabase import supabase
-from app.schemas.dos import Do, DoCreate, DoUpdate, TimeUnit, DoType
+from app.schemas.dos import Do, DoCreate, DoUpdate, MaintenanceLog, TimeUnit, DoType
 from app.services.maintenance import get_count, inject_counts
 
 router = APIRouter()
@@ -55,7 +55,6 @@ async def update_do(
     payload: DoUpdate,
     current_user: dict = Depends(get_current_user),
 ):
-    # Verify ownership before updating
     existing = (
         supabase.table("dos")
         .select("id")
@@ -85,7 +84,6 @@ async def update_do(
             if not parent_check.data:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Parent do not found")
             updates["parent_id"] = str(updates["parent_id"])
-        # None is left as None to unset the parent_id
 
     result = supabase.table("dos").update(updates).eq("id", do_id).execute()
     do = result.data[0]
@@ -94,6 +92,34 @@ async def update_do(
     today_str = datetime.now(timezone.utc).date().isoformat()
     do["is_today_priority"] = (do.get("priority_date") == today_str)
     return do
+
+
+@router.get("/{do_id}/logs", response_model=list[MaintenanceLog])
+async def list_maintenance_logs(
+    do_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    existing = (
+        supabase.table("dos")
+        .select("id,do_type")
+        .eq("id", do_id)
+        .eq("user_id", _user_id(current_user))
+        .execute()
+    )
+    if not existing.data:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Do not found")
+    if existing.data[0]["do_type"] != DoType.maintenance.value:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only maintenance dos have logs")
+
+    result = (
+        supabase.table("maintenance_logs")
+        .select("*")
+        .eq("do_id", do_id)
+        .eq("user_id", _user_id(current_user))
+        .order("logged_at", desc=True)
+        .execute()
+    )
+    return result.data or []
 
 
 @router.post("/{do_id}/log", response_model=Do)
@@ -143,10 +169,8 @@ async def toggle_priority(
     today_str = datetime.now(timezone.utc).date().isoformat()
 
     if do_row.get("priority_date") == today_str:
-        # Toggle off
         result = supabase.table("dos").update({"priority_date": None}).eq("id", do_id).execute()
     else:
-        # Clear any existing today-priority for this user, then set this one
         supabase.table("dos").update({"priority_date": None}).eq("user_id", user_id).eq("priority_date", today_str).execute()
         result = supabase.table("dos").update({"priority_date": today_str}).eq("id", do_id).execute()
 

--- a/backend/app/schemas/dos.py
+++ b/backend/app/schemas/dos.py
@@ -48,3 +48,10 @@ class Do(BaseModel):
     updated_at: datetime
     parent_id: uuid.UUID | None = None
     is_today_priority: bool = False
+
+
+class MaintenanceLog(BaseModel):
+    id: uuid.UUID
+    do_id: uuid.UUID
+    user_id: uuid.UUID
+    logged_at: datetime

--- a/backend/app/schemas/dos.py
+++ b/backend/app/schemas/dos.py
@@ -35,7 +35,6 @@ class DoUpdate(BaseModel):
 
 class Do(BaseModel):
     id: uuid.UUID
-    user_id: uuid.UUID
     title: str
     time_unit: TimeUnit
     do_type: DoType
@@ -53,5 +52,4 @@ class Do(BaseModel):
 class MaintenanceLog(BaseModel):
     id: uuid.UUID
     do_id: uuid.UUID
-    user_id: uuid.UUID
     logged_at: datetime

--- a/frontend/src/components/DoItem.tsx
+++ b/frontend/src/components/DoItem.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useRef, useState } from "react"
 import { useDraggable, useDroppable } from "@dnd-kit/core"
 import { cn } from "@/lib/utils"
-import { useToggleDo, useDeleteDo, useLogMaintenance, useRenameDo, useMoveDo, useCreateDo, useTogglePriority } from "@/hooks/useDos"
+import { useToggleDo, useDeleteDo, useLogMaintenance, useMaintenanceLogs, useRenameDo, useMoveDo, useCreateDo, useTogglePriority } from "@/hooks/useDos"
 import { Star } from "lucide-react"
 import { getPeriodLabel } from "@/lib/time"
 import { AncestryContext } from "@/components/FlowBoard"
@@ -27,6 +27,11 @@ const CHILD_UNIT: Record<TimeUnit, TimeUnit> = {
   week: "today",
   today: "today",
 }
+
+const maintenanceLogDateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+})
 
 interface Props {
   item: Do
@@ -68,6 +73,7 @@ export function DoItem({ item }: Props) {
   const [showPicker, setShowPicker] = useState(false)
   const [showAddChild, setShowAddChild] = useState(false)
   const [showAncestryPanel, setShowAncestryPanel] = useState(false)
+  const [showMaintenanceHistory, setShowMaintenanceHistory] = useState(false)
 
   const optionsRef = useRef<HTMLDivElement>(null)
 
@@ -105,6 +111,7 @@ export function DoItem({ item }: Props) {
   const isMaintenance = item.do_type === "maintenance"
   const hasParent = !!item.parent_id
   const hasChildren = allDos.some((d) => d.parent_id === item.id)
+  const maintenanceLogs = useMaintenanceLogs(item.id, isMaintenance && showMaintenanceHistory)
 
   // Time-unit navigation
   const currentIdx = TIME_UNITS.indexOf(item.time_unit)
@@ -410,16 +417,31 @@ export function DoItem({ item }: Props) {
           )}
 
           {isMaintenance ? (
-            <span className="text-xs text-[#7b8ea6]/60 flex-none">
-              {movingDoId === item.id ? (
-                <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" strokeOpacity="0.25" />
-                  <path fill="currentColor" fillOpacity="0.75" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
-              ) : (
-                <>{item.completion_count}× {getPeriodLabel(item.time_unit)}</>
-              )}
-            </span>
+            <div className="flex items-center gap-1.5 flex-none">
+              <span className="text-xs text-[#7b8ea6]/60">
+                {movingDoId === item.id ? (
+                  <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
+                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" strokeOpacity="0.25" />
+                    <path fill="currentColor" fillOpacity="0.75" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                ) : (
+                  <>{item.completion_count}× {getPeriodLabel(item.time_unit)}</>
+                )}
+              </span>
+              <button
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setShowMaintenanceHistory((value) => !value)
+                }}
+                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] text-[#7b8ea6] hover:bg-[#202945]/5 hover:text-[#202945] transition-colors"
+                aria-expanded={showMaintenanceHistory}
+                aria-label={showMaintenanceHistory ? "Hide completion history" : "Show completion history"}
+              >
+                <span>History</span>
+                <span className="text-[10px]">{showMaintenanceHistory ? "▲" : "▼"}</span>
+              </button>
+            </div>
           ) : (
             item.flow_count > 0 && !item.completed && (
               <span
@@ -431,6 +453,30 @@ export function DoItem({ item }: Props) {
             )
           )}
         </div>
+
+        {isMaintenance && showMaintenanceHistory && (
+          <div
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            className="mx-3 mb-3 rounded-lg border border-[#202945]/10 bg-[#f7f8fb] px-3 py-2"
+          >
+            {maintenanceLogs.isLoading ? (
+              <div className="text-xs text-[#7b8ea6]">Loading completion history…</div>
+            ) : maintenanceLogs.isError ? (
+              <div className="text-xs text-red-500">Couldn’t load completion history.</div>
+            ) : maintenanceLogs.data && maintenanceLogs.data.length > 0 ? (
+              <ul className="space-y-1">
+                {maintenanceLogs.data.map((log) => (
+                  <li key={log.id} className="text-xs text-[#4a587c]">
+                    {maintenanceLogDateFormatter.format(new Date(log.logged_at))}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-xs text-[#7b8ea6]">No completion history yet.</div>
+            )}
+          </div>
+        )}
 
         {/* Parent picker popover */}
         {showPicker && (

--- a/frontend/src/components/DoItem.tsx
+++ b/frontend/src/components/DoItem.tsx
@@ -73,7 +73,6 @@ export function DoItem({ item }: Props) {
   const [showPicker, setShowPicker] = useState(false)
   const [showAddChild, setShowAddChild] = useState(false)
   const [showAncestryPanel, setShowAncestryPanel] = useState(false)
-  const [showMaintenanceHistory, setShowMaintenanceHistory] = useState(false)
 
   const optionsRef = useRef<HTMLDivElement>(null)
 
@@ -111,7 +110,6 @@ export function DoItem({ item }: Props) {
   const isMaintenance = item.do_type === "maintenance"
   const hasParent = !!item.parent_id
   const hasChildren = allDos.some((d) => d.parent_id === item.id)
-  const maintenanceLogs = useMaintenanceLogs(item.id, isMaintenance && showMaintenanceHistory)
 
   // Time-unit navigation
   const currentIdx = TIME_UNITS.indexOf(item.time_unit)
@@ -347,7 +345,7 @@ export function DoItem({ item }: Props) {
               : undefined
           }
           className={cn(
-            "flex items-center gap-2 px-3 pb-3.5",
+            "flex flex-wrap items-center gap-2 px-3 pb-3.5",
             isMaintenance && "cursor-pointer",
             isMaintenance && logMaintenance.isPending && "pointer-events-none opacity-60",
           )}
@@ -417,31 +415,12 @@ export function DoItem({ item }: Props) {
           )}
 
           {isMaintenance ? (
-            <div className="flex items-center gap-1.5 flex-none">
-              <span className="text-xs text-[#7b8ea6]/60">
-                {movingDoId === item.id ? (
-                  <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" strokeOpacity="0.25" />
-                    <path fill="currentColor" fillOpacity="0.75" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                  </svg>
-                ) : (
-                  <>{item.completion_count}× {getPeriodLabel(item.time_unit)}</>
-                )}
-              </span>
-              <button
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setShowMaintenanceHistory((value) => !value)
-                }}
-                className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] text-[#7b8ea6] hover:bg-[#202945]/5 hover:text-[#202945] transition-colors"
-                aria-expanded={showMaintenanceHistory}
-                aria-label={showMaintenanceHistory ? "Hide completion history" : "Show completion history"}
-              >
-                <span>History</span>
-                <span className="text-[10px]">{showMaintenanceHistory ? "▲" : "▼"}</span>
-              </button>
-            </div>
+            <MaintenanceHistorySection
+              doId={item.id}
+              timeUnit={item.time_unit}
+              completionCount={item.completion_count}
+              isMoving={movingDoId === item.id}
+            />
           ) : (
             item.flow_count > 0 && !item.completed && (
               <span
@@ -453,30 +432,6 @@ export function DoItem({ item }: Props) {
             )
           )}
         </div>
-
-        {isMaintenance && showMaintenanceHistory && (
-          <div
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
-            className="mx-3 mb-3 rounded-lg border border-[#202945]/10 bg-[#f7f8fb] px-3 py-2"
-          >
-            {maintenanceLogs.isLoading ? (
-              <div className="text-xs text-[#7b8ea6]">Loading completion history…</div>
-            ) : maintenanceLogs.isError ? (
-              <div className="text-xs text-red-500">Couldn’t load completion history.</div>
-            ) : maintenanceLogs.data && maintenanceLogs.data.length > 0 ? (
-              <ul className="space-y-1">
-                {maintenanceLogs.data.map((log) => (
-                  <li key={log.id} className="text-xs text-[#4a587c]">
-                    {maintenanceLogDateFormatter.format(new Date(log.logged_at))}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <div className="text-xs text-[#7b8ea6]">No completion history yet.</div>
-            )}
-          </div>
-        )}
 
         {/* Parent picker popover */}
         {showPicker && (
@@ -528,6 +483,85 @@ export function DoItem({ item }: Props) {
         />
       )}
     </div>
+  )
+}
+
+function MaintenanceHistorySection({
+  doId,
+  timeUnit,
+  completionCount,
+  isMoving,
+}: {
+  doId: string
+  timeUnit: TimeUnit
+  completionCount: number
+  isMoving: boolean
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const maintenanceLogs = useMaintenanceLogs(doId, isOpen)
+  const hasHistory = completionCount > 0 || (maintenanceLogs.data?.length ?? 0) > 0
+  const historyCount = maintenanceLogs.data?.length ?? completionCount
+
+  return (
+    <>
+      <div className="flex items-center gap-1.5 flex-none">
+        <span className="text-xs text-[#7b8ea6]/60">
+          {isMoving ? (
+            <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" strokeOpacity="0.25" />
+              <path fill="currentColor" fillOpacity="0.75" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          ) : (
+            <>{completionCount}× {getPeriodLabel(timeUnit)}</>
+          )}
+        </span>
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation()
+            if (!hasHistory) return
+            setIsOpen((value) => !value)
+          }}
+          disabled={!hasHistory}
+          className={cn(
+            "flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] transition-colors",
+            hasHistory
+              ? "text-[#7b8ea6] hover:bg-[#202945]/5 hover:text-[#202945]"
+              : "text-[#7b8ea6]/45 cursor-not-allowed",
+          )}
+          aria-expanded={isOpen}
+          aria-label={isOpen ? "Hide completion history" : "Show completion history"}
+        >
+          <span>History ({historyCount})</span>
+          {hasHistory && <span className="text-[10px]">{isOpen ? "▲" : "▼"}</span>}
+        </button>
+      </div>
+
+      {isOpen && (
+        <div
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          className="basis-full mt-1 rounded-lg border border-[#202945]/10 bg-[#f7f8fb] px-3 py-2"
+        >
+          {maintenanceLogs.isLoading ? (
+            <div className="text-xs text-[#7b8ea6]">Loading completion history…</div>
+          ) : maintenanceLogs.isError ? (
+            <div className="text-xs text-red-500">Couldn’t load completion history.</div>
+          ) : maintenanceLogs.data && maintenanceLogs.data.length > 0 ? (
+            <ul className="space-y-1">
+              {maintenanceLogs.data.map((log) => (
+                <li key={log.id} className="text-xs text-[#4a587c]">
+                  {maintenanceLogDateFormatter.format(new Date(log.logged_at))}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="text-xs text-[#7b8ea6]">No completion history yet.</div>
+          )}
+        </div>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/hooks/useDos.ts
+++ b/frontend/src/hooks/useDos.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
-import type { Do, DoType, TimeUnit } from "@/types"
+import type { Do, DoType, MaintenanceLog, TimeUnit } from "@/types"
 
 export function useDos(timeUnit: TimeUnit) {
   return useQuery({
@@ -108,6 +108,17 @@ export function useUnsetParent() {
   })
 }
 
+export function useMaintenanceLogs(id: string, enabled = true) {
+  return useQuery({
+    queryKey: ["maintenance-logs", id],
+    enabled,
+    queryFn: async () => {
+      const { data } = await api.get<MaintenanceLog[]>(`/api/v1/dos/${id}/logs`)
+      return data
+    },
+  })
+}
+
 export function useLogMaintenance() {
   const queryClient = useQueryClient()
   return useMutation({
@@ -117,21 +128,23 @@ export function useLogMaintenance() {
     },
     onMutate: async ({ id, timeUnit }) => {
       await queryClient.cancelQueries({ queryKey: ["dos", timeUnit] })
+      await queryClient.cancelQueries({ queryKey: ["maintenance-logs", id] })
       const previous = queryClient.getQueryData<Do[]>(["dos", timeUnit])
       queryClient.setQueryData<Do[]>(["dos", timeUnit], (old) =>
         old?.map((d) =>
           d.id === id ? { ...d, completion_count: d.completion_count + 1 } : d,
         ) ?? [],
       )
-      return { previous, timeUnit }
+      return { previous, timeUnit, id }
     },
     onError: (_err, _vars, context) => {
       if (context?.previous !== undefined) {
         queryClient.setQueryData(["dos", context.timeUnit], context.previous)
       }
     },
-    onSettled: (_data, _err, { timeUnit }) => {
+    onSettled: (_data, _err, { id, timeUnit }) => {
       void queryClient.invalidateQueries({ queryKey: ["dos", timeUnit] })
+      void queryClient.invalidateQueries({ queryKey: ["maintenance-logs", id] })
     },
   })
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -25,3 +25,10 @@ export interface Do {
   parent_id: string | null
   is_today_priority: boolean
 }
+
+export interface MaintenanceLog {
+  id: string
+  do_id: string
+  user_id: string
+  logged_at: string
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,7 +11,6 @@ export interface SortOption {
 
 export interface Do {
   id: string
-  user_id: string
   title: string
   time_unit: TimeUnit
   do_type: DoType
@@ -29,6 +28,5 @@ export interface Do {
 export interface MaintenanceLog {
   id: string
   do_id: string
-  user_id: string
   logged_at: string
 }


### PR DESCRIPTION
## Summary
- add a maintenance log history endpoint and typed response model
- add a small History toggle on maintenance dos that expands a collapsed drawer
- render all completion instances with human-readable timestamps and refresh history after new logs

Closes #30